### PR TITLE
Added some classifiers for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,17 @@ setuptools.setup(
     license="GPLv3",
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.7"
+    python_requires=">=3.7",
+    classifiers=[
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+    ]
 )


### PR DESCRIPTION
I only added classifiers i'm sure they are correct.
Tests show that the library runs on all the listed python versions and on both CPython and PyPy.

Some classifiers i wasn't sure:
- `Development Status :: 4 - Beta` Looking at this little "article" about [Stages of development](https://martin-thoma.com/software-development-stages/) i'm not sure which of the classifiers should be added
- `Environment :: Console` I think it is correct, but i don't have to deal with classifiers often. Also there are no explanations about them, so...
- `Operating System :: OS Independent` Basically this is correct to, because the library tries to be OS independent. But in my opinion it isn't tested enough on Windows.
- `Topic :: Terminals` or `Topic :: Software Development :: Libraries :: Python Modules` or both? Not quite sure.
- `Intended Audience :: Developers` think this is true too, but eventually i just misinterpreted the use of the library