### PR TITLE
Fixed/Completed type annotations

### DIFF
--- a/src/AthenaColor/data/style.py
+++ b/src/AthenaColor/data/style.py
@@ -4,6 +4,8 @@
 # General Packages
 from __future__ import annotations
 
+from typing import Any
+
 # Custom Library
 
 # Custom Packages
@@ -150,111 +152,111 @@ sep_ = " "
 #   BUT, given it depends so much on the code above I've decided to place it here
 class StyleNest:
     @staticmethod
-    def Reset(*obj,sep=sep_):                      return NCSNO(obj,Style.Reset,sep)
+    def Reset(*obj:tuple[Any, ...],sep:str=sep_) -> str:                      return NCSNO(obj,Style.Reset,sep)
     @staticmethod
-    def Bold(*obj,sep=sep_):                       return NCS(obj,Style.Bold,Style.NoBold,sep)
+    def Bold(*obj:tuple[Any, ...],sep:str=sep_) -> str:                       return NCS(obj,Style.Bold,Style.NoBold,sep)
     @staticmethod
-    def NoBold(*obj,sep=sep_):                     return NCSNO(obj,Style.NoBold,sep)
+    def NoBold(*obj:tuple[Any, ...],sep:str=sep_) -> str:                     return NCSNO(obj,Style.NoBold,sep)
     @staticmethod
-    def Dim(*obj,sep=sep_):                        return NCS(obj,Style.Dim,Style.NoBold,sep)
+    def Dim(*obj:tuple[Any, ...],sep:str=sep_) -> str:                        return NCS(obj,Style.Dim,Style.NoBold,sep)
     @staticmethod
-    def NoDim(*obj,sep=sep_):                      return NCSNO(obj,Style.NoBold,sep)
+    def NoDim(*obj:tuple[Any, ...],sep:str=sep_) -> str:                      return NCSNO(obj,Style.NoBold,sep)
     @staticmethod
-    def Italic(*obj,sep=sep_):                     return NCS(obj,Style.Italic,Style.NoItalic,sep)
+    def Italic(*obj:tuple[Any, ...],sep:str=sep_) -> str:                     return NCS(obj,Style.Italic,Style.NoItalic,sep)
     @staticmethod
-    def NoItalic(*obj,sep=sep_):                   return NCSNO(obj,Style.NoItalic,sep)
+    def NoItalic(*obj:tuple[Any, ...],sep:str=sep_) -> str:                   return NCSNO(obj,Style.NoItalic,sep)
     @staticmethod
-    def Underline(*obj,sep=sep_):                  return NCS(obj,Style.Underline,Style.NoUnderline,sep)
+    def Underline(*obj:tuple[Any, ...],sep:str=sep_) -> str:                  return NCS(obj,Style.Underline,Style.NoUnderline,sep)
     @staticmethod
-    def NoUnderline(*obj,sep=sep_):                return NCSNO(obj,Style.NoUnderline,sep)
+    def NoUnderline(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCSNO(obj,Style.NoUnderline,sep)
     @staticmethod
-    def BlinkSlow(*obj,sep=sep_):                  return NCS(obj,Style.BlinkSlow,Style.NoBlinkSlow,sep)
+    def BlinkSlow(*obj:tuple[Any, ...],sep:str=sep_) -> str:                  return NCS(obj,Style.BlinkSlow,Style.NoBlinkSlow,sep)
     @staticmethod
-    def NoBlinkSlow(*obj,sep=sep_):                return NCSNO(obj,Style.NoBlinkSlow,sep)
+    def NoBlinkSlow(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCSNO(obj,Style.NoBlinkSlow,sep)
     @staticmethod
-    def BlinkRapid(*obj,sep=sep_):                 return NCS(obj,Style.BlinkRapid,Style.NoBlinkRapid,sep)
+    def BlinkRapid(*obj:tuple[Any, ...],sep:str=sep_) -> str:                 return NCS(obj,Style.BlinkRapid,Style.NoBlinkRapid,sep)
     @staticmethod
-    def NoBlinkRapid(*obj,sep=sep_):               return NCSNO(obj,Style.NoBlinkRapid,sep)
+    def NoBlinkRapid(*obj:tuple[Any, ...],sep:str=sep_) -> str:               return NCSNO(obj,Style.NoBlinkRapid,sep)
     @staticmethod
-    def Reversed(*obj,sep=sep_):                   return NCS(obj,Style.Reversed,Style.NoReversed,sep)
+    def Reversed(*obj:tuple[Any, ...],sep:str=sep_) -> str:                   return NCS(obj,Style.Reversed,Style.NoReversed,sep)
     @staticmethod
-    def NoReversed(*obj,sep=sep_):                 return NCSNO(obj,Style.NoReversed,sep)
+    def NoReversed(*obj:tuple[Any, ...],sep:str=sep_) -> str:                 return NCSNO(obj,Style.NoReversed,sep)
     @staticmethod
-    def Conceal(*obj,sep=sep_):                    return NCS(obj,Style.Conceal,Style.NoConceal,sep)
+    def Conceal(*obj:tuple[Any, ...],sep:str=sep_) -> str:                    return NCS(obj,Style.Conceal,Style.NoConceal,sep)
     @staticmethod
-    def NoConceal(*obj,sep=sep_):                  return NCSNO(obj,Style.NoConceal,sep)
+    def NoConceal(*obj:tuple[Any, ...],sep:str=sep_) -> str:                  return NCSNO(obj,Style.NoConceal,sep)
     @staticmethod
-    def Crossed(*obj,sep=sep_):                    return NCS(obj,Style.Crossed,Style.NoCrossed,sep)
+    def Crossed(*obj:tuple[Any, ...],sep:str=sep_) -> str:                    return NCS(obj,Style.Crossed,Style.NoCrossed,sep)
     @staticmethod
-    def NoCrossed(*obj,sep=sep_):                  return NCSNO(obj,Style.NoCrossed,sep)
+    def NoCrossed(*obj:tuple[Any, ...],sep:str=sep_) -> str:                  return NCSNO(obj,Style.NoCrossed,sep)
     @staticmethod
-    def FontPrimary(*obj,sep=sep_):                return NCS(obj,Style.NoFont,Style.NoFont,sep)
+    def FontPrimary(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.NoFont,Style.NoFont,sep)
     @staticmethod
-    def FontSecond1(*obj,sep=sep_):                return NCS(obj,Style.FontSecond1,Style.NoFont,sep)
+    def FontSecond1(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond1,Style.NoFont,sep)
     @staticmethod
-    def FontSecond2(*obj,sep=sep_):                return NCS(obj,Style.FontSecond2,Style.NoFont,sep)
+    def FontSecond2(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond2,Style.NoFont,sep)
     @staticmethod
-    def FontSecond3(*obj,sep=sep_):                return NCS(obj,Style.FontSecond3,Style.NoFont,sep)
+    def FontSecond3(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond3,Style.NoFont,sep)
     @staticmethod
-    def FontSecond4(*obj,sep=sep_):                return NCS(obj,Style.FontSecond4,Style.NoFont,sep)
+    def FontSecond4(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond4,Style.NoFont,sep)
     @staticmethod
-    def FontSecond5(*obj,sep=sep_):                return NCS(obj,Style.FontSecond5,Style.NoFont,sep)
+    def FontSecond5(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond5,Style.NoFont,sep)
     @staticmethod
-    def FontSecond6(*obj,sep=sep_):                return NCS(obj,Style.FontSecond6,Style.NoFont,sep)
+    def FontSecond6(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond6,Style.NoFont,sep)
     @staticmethod
-    def FontSecond8(*obj,sep=sep_):                return NCS(obj,Style.FontSecond8,Style.NoFont,sep)
+    def FontSecond8(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond8,Style.NoFont,sep)
     @staticmethod
-    def FontSecond9(*obj,sep=sep_):                return NCS(obj,Style.FontSecond9,Style.NoFont,sep)
+    def FontSecond9(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.FontSecond9,Style.NoFont,sep)
     @staticmethod
-    def FontSecond10(*obj,sep=sep_):               return NCS(obj,Style.FontSecond10,Style.NoFont,sep)
+    def FontSecond10(*obj:tuple[Any, ...],sep:str=sep_) -> str:               return NCS(obj,Style.FontSecond10,Style.NoFont,sep)
     @staticmethod
-    def NoFont(*obj,sep=sep_):                     return NCSNO(obj,Style.NoFont,sep)
+    def NoFont(*obj:tuple[Any, ...],sep:str=sep_) -> str:                     return NCSNO(obj,Style.NoFont,sep)
     @staticmethod
-    def Fraktur(*obj,sep=sep_):                    return NCSNO(obj,Style.Fraktur,sep)
+    def Fraktur(*obj:tuple[Any, ...],sep:str=sep_) -> str:                    return NCSNO(obj,Style.Fraktur,sep)
     @staticmethod
-    def UnderlineDouble(*obj,sep=sep_):            return NCS(obj,Style.UnderlineDouble,Style.NoUnderline,sep)
+    def UnderlineDouble(*obj:tuple[Any, ...],sep:str=sep_) -> str:            return NCS(obj,Style.UnderlineDouble,Style.NoUnderline,sep)
     @staticmethod
-    def NoUnderlineDouble(*obj,sep=sep_):          return NCSNO(obj,Style.NoUnderline,sep)
+    def NoUnderlineDouble(*obj:tuple[Any, ...],sep:str=sep_) -> str:          return NCSNO(obj,Style.NoUnderline,sep)
     @staticmethod
-    def PropSpacing(*obj,sep=sep_):                return NCS(obj,Style.PropSpacing,Style.NoPropSpacing,sep)
+    def PropSpacing(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.PropSpacing,Style.NoPropSpacing,sep)
     @staticmethod
-    def NoPropSpacing(*obj,sep=sep_):              return NCSNO(obj,Style.NoPropSpacing,sep)
+    def NoPropSpacing(*obj:tuple[Any, ...],sep:str=sep_) -> str:              return NCSNO(obj,Style.NoPropSpacing,sep)
     @staticmethod
-    def NoForeground(*obj,sep=sep_):               return NCSNO(obj,Style.NoForeground,sep)
+    def NoForeground(*obj:tuple[Any, ...],sep:str=sep_) -> str:               return NCSNO(obj,Style.NoForeground,sep)
     @staticmethod
-    def NoBackground(*obj,sep=sep_):               return NCSNO(obj,Style.NoBackground,sep)
+    def NoBackground(*obj:tuple[Any, ...],sep:str=sep_) -> str:               return NCSNO(obj,Style.NoBackground,sep)
     @staticmethod
-    def Frame(*obj,sep=sep_):                      return NCS(obj,Style.Frame,Style.NoFrame,sep)
+    def Frame(*obj:tuple[Any, ...],sep:str=sep_) -> str:                      return NCS(obj,Style.Frame,Style.NoFrame,sep)
     @staticmethod
-    def NoFrame(*obj,sep=sep_):                    return NCSNO(obj,Style.NoFrame,sep)
+    def NoFrame(*obj:tuple[Any, ...],sep:str=sep_) -> str:                    return NCSNO(obj,Style.NoFrame,sep)
     @staticmethod
-    def Circle(*obj,sep=sep_):                     return NCS(obj,Style.Circle,Style.NoFrame,sep)
+    def Circle(*obj:tuple[Any, ...],sep:str=sep_) -> str:                     return NCS(obj,Style.Circle,Style.NoFrame,sep)
     @staticmethod
-    def NoCircle(*obj,sep=sep_):                   return NCSNO(obj,Style.NoFrame,sep)
+    def NoCircle(*obj:tuple[Any, ...],sep:str=sep_) -> str:                   return NCSNO(obj,Style.NoFrame,sep)
     @staticmethod
-    def OverLine(*obj,sep=sep_):                   return NCS(obj,Style.OverLine,Style.NoOverLine,sep)
+    def OverLine(*obj:tuple[Any, ...],sep:str=sep_) -> str:                   return NCS(obj,Style.OverLine,Style.NoOverLine,sep)
     @staticmethod
-    def NoOverLine(*obj,sep=sep_):                 return NCSNO(obj,Style.NoOverLine,sep)
+    def NoOverLine(*obj:tuple[Any, ...],sep:str=sep_) -> str:                 return NCSNO(obj,Style.NoOverLine,sep)
     @staticmethod
-    def UnderColourDefault(*obj,sep=sep_):         return NCSNO(obj,Style.UnderColourDefault,sep)
+    def UnderColourDefault(*obj:tuple[Any, ...],sep:str=sep_) -> str:         return NCSNO(obj,Style.UnderColourDefault,sep)
     @staticmethod
-    def IdeogramUnderLine(*obj,sep=sep_):          return NCS(obj,Style.IdeogramUnderLine,Style.NoIdeogram,sep)
+    def IdeogramUnderLine(*obj:tuple[Any, ...],sep:str=sep_) -> str:          return NCS(obj,Style.IdeogramUnderLine,Style.NoIdeogram,sep)
     @staticmethod
-    def IdeogramUnderLineDouble(*obj,sep=sep_):    return NCS(obj,Style.IdeogramUnderLineDouble,Style.NoIdeogram,sep)
+    def IdeogramUnderLineDouble(*obj:tuple[Any, ...],sep:str=sep_) -> str:    return NCS(obj,Style.IdeogramUnderLineDouble,Style.NoIdeogram,sep)
     @staticmethod
-    def IdeogramOverLine(*obj,sep=sep_):           return NCS(obj,Style.IdeogramOverLine,Style.NoIdeogram,sep)
+    def IdeogramOverLine(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj,Style.IdeogramOverLine,Style.NoIdeogram,sep)
     @staticmethod
-    def IdeogramOverLineDouble(*obj,sep=sep_):     return NCS(obj,Style.IdeogramOverLineDouble,Style.NoIdeogram,sep)
+    def IdeogramOverLineDouble(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj,Style.IdeogramOverLineDouble,Style.NoIdeogram,sep)
     @staticmethod
-    def IdeogramStress(*obj,sep=sep_):             return NCS(obj,Style.IdeogramStress,Style.NoIdeogram,sep)
+    def IdeogramStress(*obj:tuple[Any, ...],sep:str=sep_) -> str:             return NCS(obj,Style.IdeogramStress,Style.NoIdeogram,sep)
     @staticmethod
-    def NoIdeogram(*obj,sep=sep_):                 return NCSNO(obj,Style.NoIdeogram,sep)
+    def NoIdeogram(*obj:tuple[Any, ...],sep:str=sep_) -> str:                 return NCSNO(obj,Style.NoIdeogram,sep)
     @staticmethod
-    def SuperScript(*obj,sep=sep_):                return NCS(obj,Style.SuperScript,Style.NoScript,sep)
+    def SuperScript(*obj:tuple[Any, ...],sep:str=sep_) -> str:                return NCS(obj,Style.SuperScript,Style.NoScript,sep)
     @staticmethod
-    def SubScript(*obj,sep=sep_):                  return NCS(obj,Style.SubScript,Style.NoScript,sep)
+    def SubScript(*obj:tuple[Any, ...],sep:str=sep_) -> str:                  return NCS(obj,Style.SubScript,Style.NoScript,sep)
     @staticmethod
-    def NoScript(*obj,sep=sep_):                   return NCSNO(obj,Style.NoScript,sep)
+    def NoScript(*obj:tuple[Any, ...],sep:str=sep_) -> str:                   return NCSNO(obj,Style.NoScript,sep)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - BasicNest Sequences -
@@ -262,68 +264,68 @@ class StyleNest:
 class BasicNest:
     class Fore:
         @staticmethod
-        def Black(*obj,sep=sep_):           return NCS(obj, Basic.Fore.Black, Style.NoForeground,sep)
+        def Black(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj, Basic.Fore.Black, Style.NoForeground,sep)
         @staticmethod
-        def Red(*obj,sep=sep_):             return NCS(obj, Basic.Fore.Red, Style.NoForeground,sep)
+        def Red(*obj:tuple[Any, ...],sep:str=sep_) -> str:             return NCS(obj, Basic.Fore.Red, Style.NoForeground,sep)
         @staticmethod
-        def Green(*obj,sep=sep_):           return NCS(obj, Basic.Fore.Green, Style.NoForeground,sep)
+        def Green(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj, Basic.Fore.Green, Style.NoForeground,sep)
         @staticmethod
-        def Yellow(*obj,sep=sep_):          return NCS(obj, Basic.Fore.Yellow, Style.NoForeground,sep)
+        def Yellow(*obj:tuple[Any, ...],sep:str=sep_) -> str:          return NCS(obj, Basic.Fore.Yellow, Style.NoForeground,sep)
         @staticmethod
-        def Blue(*obj,sep=sep_):            return NCS(obj, Basic.Fore.Blue, Style.NoForeground,sep)
+        def Blue(*obj:tuple[Any, ...],sep:str=sep_) -> str:            return NCS(obj, Basic.Fore.Blue, Style.NoForeground,sep)
         @staticmethod
-        def Magenta(*obj,sep=sep_):         return NCS(obj, Basic.Fore.Magenta, Style.NoForeground,sep)
+        def Magenta(*obj:tuple[Any, ...],sep:str=sep_) -> str:         return NCS(obj, Basic.Fore.Magenta, Style.NoForeground,sep)
         @staticmethod
-        def Cyan(*obj,sep=sep_):            return NCS(obj, Basic.Fore.Cyan, Style.NoForeground,sep)
+        def Cyan(*obj:tuple[Any, ...],sep:str=sep_) -> str:            return NCS(obj, Basic.Fore.Cyan, Style.NoForeground,sep)
         @staticmethod
-        def White(*obj,sep=sep_):           return NCS(obj, Basic.Fore.White, Style.NoForeground,sep)
+        def White(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj, Basic.Fore.White, Style.NoForeground,sep)
         @staticmethod
-        def BrightBlack(*obj,sep=sep_):     return NCS(obj, Basic.Fore.BrightBlack, Style.NoForeground,sep)
+        def BrightBlack(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj, Basic.Fore.BrightBlack, Style.NoForeground,sep)
         @staticmethod
-        def BrightRed(*obj,sep=sep_):       return NCS(obj, Basic.Fore.BrightRed, Style.NoForeground,sep)
+        def BrightRed(*obj:tuple[Any, ...],sep:str=sep_) -> str:       return NCS(obj, Basic.Fore.BrightRed, Style.NoForeground,sep)
         @staticmethod
-        def BrightGreen(*obj,sep=sep_):     return NCS(obj, Basic.Fore.BrightGreen, Style.NoForeground,sep)
+        def BrightGreen(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj, Basic.Fore.BrightGreen, Style.NoForeground,sep)
         @staticmethod
-        def BrightYellow(*obj,sep=sep_):    return NCS(obj, Basic.Fore.BrightYellow, Style.NoForeground,sep)
+        def BrightYellow(*obj:tuple[Any, ...],sep:str=sep_) -> str:    return NCS(obj, Basic.Fore.BrightYellow, Style.NoForeground,sep)
         @staticmethod
-        def BrightBlue(*obj,sep=sep_):      return NCS(obj, Basic.Fore.BrightBlue, Style.NoForeground,sep)
+        def BrightBlue(*obj:tuple[Any, ...],sep:str=sep_) -> str:      return NCS(obj, Basic.Fore.BrightBlue, Style.NoForeground,sep)
         @staticmethod
-        def BrightMagenta(*obj,sep=sep_):   return NCS(obj, Basic.Fore.BrightMagenta, Style.NoForeground,sep)
+        def BrightMagenta(*obj:tuple[Any, ...],sep:str=sep_) -> str:   return NCS(obj, Basic.Fore.BrightMagenta, Style.NoForeground,sep)
         @staticmethod
-        def BrightCyan(*obj,sep=sep_):      return NCS(obj, Basic.Fore.BrightCyan, Style.NoForeground,sep)
+        def BrightCyan(*obj:tuple[Any, ...],sep:str=sep_) -> str:      return NCS(obj, Basic.Fore.BrightCyan, Style.NoForeground,sep)
         @staticmethod
-        def BrightWhite(*obj,sep=sep_):     return NCS(obj, Basic.Fore.BrightWhite, Style.NoForeground,sep)
+        def BrightWhite(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj, Basic.Fore.BrightWhite, Style.NoForeground,sep)
 
     class Back:
         @staticmethod
-        def Black(*obj,sep=sep_):           return NCS(obj, Basic.Back.Black, Style.NoBackground,sep)
+        def Black(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj, Basic.Back.Black, Style.NoBackground,sep)
         @staticmethod
-        def Red(*obj,sep=sep_):             return NCS(obj, Basic.Back.Red, Style.NoBackground,sep)
+        def Red(*obj:tuple[Any, ...],sep:str=sep_) -> str:             return NCS(obj, Basic.Back.Red, Style.NoBackground,sep)
         @staticmethod
-        def Green(*obj,sep=sep_):           return NCS(obj, Basic.Back.Green, Style.NoBackground,sep)
+        def Green(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj, Basic.Back.Green, Style.NoBackground,sep)
         @staticmethod
-        def Yellow(*obj,sep=sep_):          return NCS(obj, Basic.Back.Yellow, Style.NoBackground,sep)
+        def Yellow(*obj:tuple[Any, ...],sep:str=sep_) -> str:          return NCS(obj, Basic.Back.Yellow, Style.NoBackground,sep)
         @staticmethod
-        def Blue(*obj,sep=sep_):            return NCS(obj, Basic.Back.Blue, Style.NoBackground,sep)
+        def Blue(*obj:tuple[Any, ...],sep:str=sep_) -> str:            return NCS(obj, Basic.Back.Blue, Style.NoBackground,sep)
         @staticmethod
-        def Magenta(*obj,sep=sep_):         return NCS(obj, Basic.Back.Magenta, Style.NoBackground,sep)
+        def Magenta(*obj:tuple[Any, ...],sep:str=sep_) -> str:         return NCS(obj, Basic.Back.Magenta, Style.NoBackground,sep)
         @staticmethod
-        def Cyan(*obj,sep=sep_):            return NCS(obj, Basic.Back.Cyan, Style.NoBackground,sep)
+        def Cyan(*obj:tuple[Any, ...],sep:str=sep_) -> str:            return NCS(obj, Basic.Back.Cyan, Style.NoBackground,sep)
         @staticmethod
-        def White(*obj,sep=sep_):           return NCS(obj, Basic.Back.White, Style.NoBackground,sep)
+        def White(*obj:tuple[Any, ...],sep:str=sep_) -> str:           return NCS(obj, Basic.Back.White, Style.NoBackground,sep)
         @staticmethod
-        def BrightBlack(*obj,sep=sep_):     return NCS(obj, Basic.Back.BrightBlack, Style.NoBackground,sep)
+        def BrightBlack(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj, Basic.Back.BrightBlack, Style.NoBackground,sep)
         @staticmethod
-        def BrightRed(*obj,sep=sep_):       return NCS(obj, Basic.Back.BrightRed, Style.NoBackground,sep)
+        def BrightRed(*obj:tuple[Any, ...],sep:str=sep_) -> str:       return NCS(obj, Basic.Back.BrightRed, Style.NoBackground,sep)
         @staticmethod
-        def BrightGreen(*obj,sep=sep_):     return NCS(obj, Basic.Back.BrightGreen, Style.NoBackground,sep)
+        def BrightGreen(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj, Basic.Back.BrightGreen, Style.NoBackground,sep)
         @staticmethod
-        def BrightYellow(*obj,sep=sep_):    return NCS(obj, Basic.Back.BrightYellow, Style.NoBackground,sep)
+        def BrightYellow(*obj:tuple[Any, ...],sep:str=sep_) -> str:    return NCS(obj, Basic.Back.BrightYellow, Style.NoBackground,sep)
         @staticmethod
-        def BrightBlue(*obj,sep=sep_):      return NCS(obj, Basic.Back.BrightBlue, Style.NoBackground,sep)
+        def BrightBlue(*obj:tuple[Any, ...],sep:str=sep_) -> str:      return NCS(obj, Basic.Back.BrightBlue, Style.NoBackground,sep)
         @staticmethod
-        def BrightMagenta(*obj,sep=sep_):   return NCS(obj, Basic.Back.BrightMagenta, Style.NoBackground,sep)
+        def BrightMagenta(*obj:tuple[Any, ...],sep:str=sep_) -> str:   return NCS(obj, Basic.Back.BrightMagenta, Style.NoBackground,sep)
         @staticmethod
-        def BrightCyan(*obj,sep=sep_):      return NCS(obj, Basic.Back.BrightCyan, Style.NoBackground,sep)
+        def BrightCyan(*obj:tuple[Any, ...],sep:str=sep_) -> str:      return NCS(obj, Basic.Back.BrightCyan, Style.NoBackground,sep)
         @staticmethod
-        def BrightWhite(*obj,sep=sep_):     return NCS(obj, Basic.Back.BrightWhite, Style.NoBackground,sep)
+        def BrightWhite(*obj:tuple[Any, ...],sep:str=sep_) -> str:     return NCS(obj, Basic.Back.BrightWhite, Style.NoBackground,sep)

--- a/src/AthenaColor/func/ansi_sequences.py
+++ b/src/AthenaColor/func/ansi_sequences.py
@@ -4,6 +4,7 @@
 # General Packages
 from __future__ import annotations
 
+from typing import Any
 # Custom Library
 
 # Custom Packages
@@ -21,7 +22,7 @@ def color_sequence(control_code:int|str)->str:
     """
     return f'\x1b[{control_code}m'
 
-def color_sequence_nested(obj:tuple, color_code:str, reset_code:int|str, sep:str=" ") -> str:
+def color_sequence_nested(obj:tuple[Any, ...], color_code:str, reset_code:str, sep:str=" ") -> str:
     """
     Used by Nested Console StyleNest Makeup operations like ForeNest, BackNest, StyleNest.
     Function wraps every obj in the properly defined control- and reset codes.
@@ -40,7 +41,7 @@ def color_sequence_nested(obj:tuple, color_code:str, reset_code:int|str, sep:str
         text += f"{color_code}{o}{sep}{reset_code}" # SEP moved to within the color - reset, as previously, it was color-reset anyway
     return text + f"{color_code}{obj[-1]}{reset_code}"
 
-def color_sequence_nested_no_reset(obj:tuple, color_code:int|str, sep:str=" ") -> str:
+def color_sequence_nested_no_reset(obj:tuple[Any, ...], color_code:str, sep:str=" ") -> str:
     """
     Used by Nested Console StyleNest Makeup operations like ForeNest, BackNest, StyleNest.
     Function wraps every obj in the properly defined control- and reset codes.

--- a/src/AthenaColor/models/rgb_controlled.py
+++ b/src/AthenaColor/models/rgb_controlled.py
@@ -24,557 +24,557 @@ class RgbControlled:
 
     # ------------------------------------------------------------------------------------------------------------------
     @property
-    def Maroon(self):
+    def Maroon(self) -> str:
         return self.custom(HtmlColorObjects.MAROON)
 
     @property
-    def DarkRed(self):
+    def DarkRed(self) -> str:
         return self.custom(HtmlColorObjects.DARKRED)
 
     @property
-    def Brown(self):
+    def Brown(self) -> str:
         return self.custom(HtmlColorObjects.BROWN)
 
     @property
-    def Firebrick(self):
+    def Firebrick(self) -> str:
         return self.custom(HtmlColorObjects.FIREBRICK)
 
     @property
-    def Crimson(self):
+    def Crimson(self) -> str:
         return self.custom(HtmlColorObjects.CRIMSON)
 
     @property
-    def Red(self):
+    def Red(self) -> str:
         return self.custom(HtmlColorObjects.RED)
 
     @property
-    def Tomato(self):
+    def Tomato(self) -> str:
         return self.custom(HtmlColorObjects.TOMATO)
 
     @property
-    def Coral(self):
+    def Coral(self) -> str:
         return self.custom(HtmlColorObjects.CORAL)
 
     @property
-    def IndianRed(self):
+    def IndianRed(self) -> str:
         return self.custom(HtmlColorObjects.INDIANRED)
 
     @property
-    def LightCoral(self):
+    def LightCoral(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTCORAL)
 
     @property
-    def DarkSalmon(self):
+    def DarkSalmon(self) -> str:
         return self.custom(HtmlColorObjects.DARKSALMON)
 
     @property
-    def Salmon(self):
+    def Salmon(self) -> str:
         return self.custom(HtmlColorObjects.SALMON)
 
     @property
-    def LightSalmon(self):
+    def LightSalmon(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTSALMON)
 
     @property
-    def OrangeRed(self):
+    def OrangeRed(self) -> str:
         return self.custom(HtmlColorObjects.ORANGERED)
 
     @property
-    def DarkOrange(self):
+    def DarkOrange(self) -> str:
         return self.custom(HtmlColorObjects.DARKORANGE)
 
     @property
-    def Orange(self):
+    def Orange(self) -> str:
         return self.custom(HtmlColorObjects.ORANGE)
 
     @property
-    def Gold(self):
+    def Gold(self) -> str:
         return self.custom(HtmlColorObjects.GOLD)
 
     @property
-    def DarkGoldenRod(self):
+    def DarkGoldenRod(self) -> str:
         return self.custom(HtmlColorObjects.DARKGOLDENROD)
 
     @property
-    def GoldenRod(self):
+    def GoldenRod(self) -> str:
         return self.custom(HtmlColorObjects.GOLDENROD)
 
     @property
-    def PaleGoldenRod(self):
+    def PaleGoldenRod(self) -> str:
         return self.custom(HtmlColorObjects.PALEGOLDENROD)
 
     @property
-    def DarkKhaki(self):
+    def DarkKhaki(self) -> str:
         return self.custom(HtmlColorObjects.DARKKHAKI)
 
     @property
-    def Khaki(self):
+    def Khaki(self) -> str:
         return self.custom(HtmlColorObjects.KHAKI)
 
     @property
-    def Olive(self):
+    def Olive(self) -> str:
         return self.custom(HtmlColorObjects.OLIVE)
 
     @property
-    def Yellow(self):
+    def Yellow(self) -> str:
         return self.custom(HtmlColorObjects.YELLOW)
 
     @property
-    def YellowGreen(self):
+    def YellowGreen(self) -> str:
         return self.custom(HtmlColorObjects.YELLOWGREEN)
 
     @property
-    def DarkOliveGreen(self):
+    def DarkOliveGreen(self) -> str:
         return self.custom(HtmlColorObjects.DARKOLIVEGREEN)
 
     @property
-    def OliveDrab(self):
+    def OliveDrab(self) -> str:
         return self.custom(HtmlColorObjects.OLIVEDRAB)
 
     @property
-    def LawnGreen(self):
+    def LawnGreen(self) -> str:
         return self.custom(HtmlColorObjects.LAWNGREEN)
 
     @property
-    def Chartreuse(self):
+    def Chartreuse(self) -> str:
         return self.custom(HtmlColorObjects.CHARTREUSE)
 
     @property
-    def GreenYellow(self):
+    def GreenYellow(self) -> str:
         return self.custom(HtmlColorObjects.GREENYELLOW)
 
     @property
-    def DarkGreen(self):
+    def DarkGreen(self) -> str:
         return self.custom(HtmlColorObjects.DARKGREEN)
 
     @property
-    def Green(self):
+    def Green(self) -> str:
         return self.custom(HtmlColorObjects.GREEN)
 
     @property
-    def ForestGreen(self):
+    def ForestGreen(self) -> str:
         return self.custom(HtmlColorObjects.FORESTGREEN)
 
     @property
-    def Lime(self):
+    def Lime(self) -> str:
         return self.custom(HtmlColorObjects.LIME)
 
     @property
-    def LimeGreen(self):
+    def LimeGreen(self) -> str:
         return self.custom(HtmlColorObjects.LIMEGREEN)
 
     @property
-    def LightGreen(self):
+    def LightGreen(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTGREEN)
 
     @property
-    def PaleGreen(self):
+    def PaleGreen(self) -> str:
         return self.custom(HtmlColorObjects.PALEGREEN)
 
     @property
-    def DarkSeaGreen(self):
+    def DarkSeaGreen(self) -> str:
         return self.custom(HtmlColorObjects.DARKSEAGREEN)
 
     @property
-    def MediumSpringGreen(self):
+    def MediumSpringGreen(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMSPRINGGREEN)
 
     @property
-    def SpringGreen(self):
+    def SpringGreen(self) -> str:
         return self.custom(HtmlColorObjects.SPRINGGREEN)
 
     @property
-    def SeaGreen(self):
+    def SeaGreen(self) -> str:
         return self.custom(HtmlColorObjects.SEAGREEN)
 
     @property
-    def MediumAquaMarine(self):
+    def MediumAquaMarine(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMAQUAMARINE)
 
     @property
-    def MediumSeaGreen(self):
+    def MediumSeaGreen(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMSEAGREEN)
 
     @property
-    def LightSeaGreen(self):
+    def LightSeaGreen(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTSEAGREEN)
 
     @property
-    def DarkSlateGray(self):
+    def DarkSlateGray(self) -> str:
         return self.custom(HtmlColorObjects.DARKSLATEGRAY)
 
     @property
-    def Teal(self):
+    def Teal(self) -> str:
         return self.custom(HtmlColorObjects.TEAL)
 
     @property
-    def DarkCyan(self):
+    def DarkCyan(self) -> str:
         return self.custom(HtmlColorObjects.DARKCYAN)
 
     @property
-    def Aqua(self):
+    def Aqua(self) -> str:
         return self.custom(HtmlColorObjects.AQUA)
 
     @property
-    def Cyan(self):
+    def Cyan(self) -> str:
         return self.custom(HtmlColorObjects.CYAN)
 
     @property
-    def LightCyan(self):
+    def LightCyan(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTCYAN)
 
     @property
-    def DarkTurquoise(self):
+    def DarkTurquoise(self) -> str:
         return self.custom(HtmlColorObjects.DARKTURQUOISE)
 
     @property
-    def Turquoise(self):
+    def Turquoise(self) -> str:
         return self.custom(HtmlColorObjects.TURQUOISE)
 
     @property
-    def MediumTurquoise(self):
+    def MediumTurquoise(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMTURQUOISE)
 
     @property
-    def PaleTurquoise(self):
+    def PaleTurquoise(self) -> str:
         return self.custom(HtmlColorObjects.PALETURQUOISE)
 
     @property
-    def AquaMarine(self):
+    def AquaMarine(self) -> str:
         return self.custom(HtmlColorObjects.AQUAMARINE)
 
     @property
-    def PowderBlue(self):
+    def PowderBlue(self) -> str:
         return self.custom(HtmlColorObjects.POWDERBLUE)
 
     @property
-    def CadetBlue(self):
+    def CadetBlue(self) -> str:
         return self.custom(HtmlColorObjects.CADETBLUE)
 
     @property
-    def SteelBlue(self):
+    def SteelBlue(self) -> str:
         return self.custom(HtmlColorObjects.STEELBLUE)
 
     @property
-    def CornFlowerBlue(self):
+    def CornFlowerBlue(self) -> str:
         return self.custom(HtmlColorObjects.CORNFLOWERBLUE)
 
     @property
-    def DeepSkyBlue(self):
+    def DeepSkyBlue(self) -> str:
         return self.custom(HtmlColorObjects.DEEPSKYBLUE)
 
     @property
-    def DodgerBlue(self):
+    def DodgerBlue(self) -> str:
         return self.custom(HtmlColorObjects.DODGERBLUE)
 
     @property
-    def LightBlue(self):
+    def LightBlue(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTBLUE)
 
     @property
-    def SkyBlue(self):
+    def SkyBlue(self) -> str:
         return self.custom(HtmlColorObjects.SKYBLUE)
 
     @property
-    def LightSkyBlue(self):
+    def LightSkyBlue(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTSKYBLUE)
 
     @property
-    def MidnightBlue(self):
+    def MidnightBlue(self) -> str:
         return self.custom(HtmlColorObjects.MIDNIGHTBLUE)
 
     @property
-    def Navy(self):
+    def Navy(self) -> str:
         return self.custom(HtmlColorObjects.NAVY)
 
     @property
-    def DarkBlue(self):
+    def DarkBlue(self) -> str:
         return self.custom(HtmlColorObjects.DARKBLUE)
 
     @property
-    def MediumBlue(self):
+    def MediumBlue(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMBLUE)
 
     @property
-    def Blue(self):
+    def Blue(self) -> str:
         return self.custom(HtmlColorObjects.BLUE)
 
     @property
-    def RoyalBlue(self):
+    def RoyalBlue(self) -> str:
         return self.custom(HtmlColorObjects.ROYALBLUE)
 
     @property
-    def BlueViolet(self):
+    def BlueViolet(self) -> str:
         return self.custom(HtmlColorObjects.BLUEVIOLET)
 
     @property
-    def Indigo(self):
+    def Indigo(self) -> str:
         return self.custom(HtmlColorObjects.INDIGO)
 
     @property
-    def DarkSlateBlue(self):
+    def DarkSlateBlue(self) -> str:
         return self.custom(HtmlColorObjects.DARKSLATEBLUE)
 
     @property
-    def SlateBlue(self):
+    def SlateBlue(self) -> str:
         return self.custom(HtmlColorObjects.SLATEBLUE)
 
     @property
-    def MediumSlateBlue(self):
+    def MediumSlateBlue(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMSLATEBLUE)
 
     @property
-    def MediumPurple(self):
+    def MediumPurple(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMPURPLE)
 
     @property
-    def DarkMagenta(self):
+    def DarkMagenta(self) -> str:
         return self.custom(HtmlColorObjects.DARKMAGENTA)
 
     @property
-    def DarkViolet(self):
+    def DarkViolet(self) -> str:
         return self.custom(HtmlColorObjects.DARKVIOLET)
 
     @property
-    def DarkOrchid(self):
+    def DarkOrchid(self) -> str:
         return self.custom(HtmlColorObjects.DARKORCHID)
 
     @property
-    def MediumOrchid(self):
+    def MediumOrchid(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMORCHID)
 
     @property
-    def Purple(self):
+    def Purple(self) -> str:
         return self.custom(HtmlColorObjects.PURPLE)
 
     @property
-    def Thistle(self):
+    def Thistle(self) -> str:
         return self.custom(HtmlColorObjects.THISTLE)
 
     @property
-    def Plum(self):
+    def Plum(self) -> str:
         return self.custom(HtmlColorObjects.PLUM)
 
     @property
-    def Violet(self):
+    def Violet(self) -> str:
         return self.custom(HtmlColorObjects.VIOLET)
 
     @property
-    def Magenta(self):
+    def Magenta(self) -> str:
         return self.custom(HtmlColorObjects.MAGENTA)
 
     @property
-    def Orchid(self):
+    def Orchid(self) -> str:
         return self.custom(HtmlColorObjects.ORCHID)
 
     @property
-    def MediumVioletRed(self):
+    def MediumVioletRed(self) -> str:
         return self.custom(HtmlColorObjects.MEDIUMVIOLETRED)
 
     @property
-    def PaleVioletRed(self):
+    def PaleVioletRed(self) -> str:
         return self.custom(HtmlColorObjects.PALEVIOLETRED)
 
     @property
-    def DeepPink(self):
+    def DeepPink(self) -> str:
         return self.custom(HtmlColorObjects.DEEPPINK)
 
     @property
-    def HotPink(self):
+    def HotPink(self) -> str:
         return self.custom(HtmlColorObjects.HOTPINK)
 
     @property
-    def LightPink(self):
+    def LightPink(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTPINK)
 
     @property
-    def Pink(self):
+    def Pink(self) -> str:
         return self.custom(HtmlColorObjects.PINK)
 
     @property
-    def AntiqueWhite(self):
+    def AntiqueWhite(self) -> str:
         return self.custom(HtmlColorObjects.ANTIQUEWHITE)
 
     @property
-    def Beige(self):
+    def Beige(self) -> str:
         return self.custom(HtmlColorObjects.BEIGE)
 
     @property
-    def Bisque(self):
+    def Bisque(self) -> str:
         return self.custom(HtmlColorObjects.BISQUE)
 
     @property
-    def BlanchedAlmond(self):
+    def BlanchedAlmond(self) -> str:
         return self.custom(HtmlColorObjects.BLANCHEDALMOND)
 
     @property
-    def Wheat(self):
+    def Wheat(self) -> str:
         return self.custom(HtmlColorObjects.WHEAT)
 
     @property
-    def CornSilk(self):
+    def CornSilk(self) -> str:
         return self.custom(HtmlColorObjects.CORNSILK)
 
     @property
-    def LemonChiffon(self):
+    def LemonChiffon(self) -> str:
         return self.custom(HtmlColorObjects.LEMONCHIFFON)
 
     @property
-    def LightGoldenRodYellow(self):
+    def LightGoldenRodYellow(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTGOLDENRODYELLOW)
 
     @property
-    def LightYellow(self):
+    def LightYellow(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTYELLOW)
 
     @property
-    def SaddleBrown(self):
+    def SaddleBrown(self) -> str:
         return self.custom(HtmlColorObjects.SADDLEBROWN)
 
     @property
-    def Sienna(self):
+    def Sienna(self) -> str:
         return self.custom(HtmlColorObjects.SIENNA)
 
     @property
-    def Chocolate(self):
+    def Chocolate(self) -> str:
         return self.custom(HtmlColorObjects.CHOCOLATE)
 
     @property
-    def Peru(self):
+    def Peru(self) -> str:
         return self.custom(HtmlColorObjects.PERU)
 
     @property
-    def SandyBrown(self):
+    def SandyBrown(self) -> str:
         return self.custom(HtmlColorObjects.SANDYBROWN)
 
     @property
-    def BurlyWood(self):
+    def BurlyWood(self) -> str:
         return self.custom(HtmlColorObjects.BURLYWOOD)
 
     @property
-    def Tan(self):
+    def Tan(self) -> str:
         return self.custom(HtmlColorObjects.TAN)
 
     @property
-    def RosyBrown(self):
+    def RosyBrown(self) -> str:
         return self.custom(HtmlColorObjects.ROSYBROWN)
 
     @property
-    def Moccasin(self):
+    def Moccasin(self) -> str:
         return self.custom(HtmlColorObjects.MOCCASIN)
 
     @property
-    def NavajoWhite(self):
+    def NavajoWhite(self) -> str:
         return self.custom(HtmlColorObjects.NAVAJOWHITE)
 
     @property
-    def PeachPuff(self):
+    def PeachPuff(self) -> str:
         return self.custom(HtmlColorObjects.PEACHPUFF)
 
     @property
-    def MistyRose(self):
+    def MistyRose(self) -> str:
         return self.custom(HtmlColorObjects.MISTYROSE)
 
     @property
-    def LavenderBlush(self):
+    def LavenderBlush(self) -> str:
         return self.custom(HtmlColorObjects.LAVENDERBLUSH)
 
     @property
-    def Linen(self):
+    def Linen(self) -> str:
         return self.custom(HtmlColorObjects.LINEN)
 
     @property
-    def OldLace(self):
+    def OldLace(self) -> str:
         return self.custom(HtmlColorObjects.OLDLACE)
 
     @property
-    def PapayaWhip(self):
+    def PapayaWhip(self) -> str:
         return self.custom(HtmlColorObjects.PAPAYAWHIP)
 
     @property
-    def WeaShell(self):
+    def WeaShell(self) -> str:
         return self.custom(HtmlColorObjects.WEASHELL)
 
     @property
-    def MintCream(self):
+    def MintCream(self) -> str:
         return self.custom(HtmlColorObjects.MINTCREAM)
 
     @property
-    def SlateGray(self):
+    def SlateGray(self) -> str:
         return self.custom(HtmlColorObjects.SLATEGRAY)
 
     @property
-    def LightSlateGray(self):
+    def LightSlateGray(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTSLATEGRAY)
 
     @property
-    def LightSteelBlue(self):
+    def LightSteelBlue(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTSTEELBLUE)
 
     @property
-    def Lavender(self):
+    def Lavender(self) -> str:
         return self.custom(HtmlColorObjects.LAVENDER)
 
     @property
-    def FloralWhite(self):
+    def FloralWhite(self) -> str:
         return self.custom(HtmlColorObjects.FLORALWHITE)
 
     @property
-    def AliceBlue(self):
+    def AliceBlue(self) -> str:
         return self.custom(HtmlColorObjects.ALICEBLUE)
 
     @property
-    def GhostWhite(self):
+    def GhostWhite(self) -> str:
         return self.custom(HtmlColorObjects.GHOSTWHITE)
 
     @property
-    def Honeydew(self):
+    def Honeydew(self) -> str:
         return self.custom(HtmlColorObjects.HONEYDEW)
 
     @property
-    def Ivory(self):
+    def Ivory(self) -> str:
         return self.custom(HtmlColorObjects.IVORY)
 
     @property
-    def Azure(self):
+    def Azure(self) -> str:
         return self.custom(HtmlColorObjects.AZURE)
 
     @property
-    def Snow(self):
+    def Snow(self) -> str:
         return self.custom(HtmlColorObjects.SNOW)
 
     @property
-    def Black(self):
+    def Black(self) -> str:
         return self.custom(HtmlColorObjects.BLACK)
 
     @property
-    def DimGray(self):
+    def DimGray(self) -> str:
         return self.custom(HtmlColorObjects.DIMGRAY)
 
     @property
-    def Gray(self):
+    def Gray(self) -> str:
         return self.custom(HtmlColorObjects.GRAY)
 
     @property
-    def DarkGray(self):
+    def DarkGray(self) -> str:
         return self.custom(HtmlColorObjects.DARKGRAY)
 
     @property
-    def Silver(self):
+    def Silver(self) -> str:
         return self.custom(HtmlColorObjects.SILVER)
 
     @property
-    def LightGray(self):
+    def LightGray(self) -> str:
         return self.custom(HtmlColorObjects.LIGHTGRAY)
 
     @property
-    def Gainsboro(self):
+    def Gainsboro(self) -> str:
         return self.custom(HtmlColorObjects.GAINSBORO)
 
     @property
-    def WhiteSmoke(self):
+    def WhiteSmoke(self) -> str:
         return self.custom(HtmlColorObjects.WHITESMOKE)
 
     @property
-    def White(self):
+    def White(self) -> str:
         return self.custom(HtmlColorObjects.WHITE)

--- a/src/AthenaColor/models/rgb_controlled_nested.py
+++ b/src/AthenaColor/models/rgb_controlled_nested.py
@@ -4,6 +4,7 @@
 # General Packages
 from __future__ import annotations
 
+from typing import Any
 # Custom Library
 
 # Custom Packages
@@ -28,7 +29,7 @@ class RgbControlledNested:
         self._inline_class = inline_class
         self._reset = reset
 
-    def custom(self,*obj, color:tuple[int,int,int], sep=sep_) -> str:
+    def custom(self,*obj:tuple[Any, ...], color:tuple[int,int,int], sep:str=sep_) -> str:
         return color_sequence_nested(
             obj,
             color_sequence(f"{self._inline_class.param_code}{color[0]};{color[1]};{color[2]}"),
@@ -37,419 +38,419 @@ class RgbControlledNested:
         )
 
     # ------------------------------------------------------------------------------------------------------------------
-    def Maroon(self, *obj, sep=sep_):
+    def Maroon(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MAROON,sep=sep)
 
-    def DarkRed(self, *obj, sep=sep_):
+    def DarkRed(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKRED,sep=sep)
 
-    def Brown(self, *obj, sep=sep_):
+    def Brown(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BROWN,sep=sep)
 
-    def Firebrick(self, *obj, sep=sep_):
+    def Firebrick(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.FIREBRICK,sep=sep)
 
-    def Crimson(self, *obj, sep=sep_):
+    def Crimson(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CRIMSON,sep=sep)
 
-    def Red(self, *obj, sep=sep_):
+    def Red(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.RED,sep=sep)
 
-    def Tomato(self, *obj, sep=sep_):
+    def Tomato(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.TOMATO,sep=sep)
 
-    def Coral(self, *obj, sep=sep_):
+    def Coral(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CORAL,sep=sep)
 
-    def IndianRed(self, *obj, sep=sep_):
+    def IndianRed(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.INDIANRED,sep=sep)
 
-    def LightCoral(self, *obj, sep=sep_):
+    def LightCoral(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTCORAL,sep=sep)
 
-    def DarkSalmon(self, *obj, sep=sep_):
+    def DarkSalmon(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKSALMON,sep=sep)
 
-    def Salmon(self, *obj, sep=sep_):
+    def Salmon(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SALMON,sep=sep)
 
-    def LightSalmon(self, *obj, sep=sep_):
+    def LightSalmon(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTSALMON,sep=sep)
 
-    def OrangeRed(self, *obj, sep=sep_):
+    def OrangeRed(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ORANGERED,sep=sep)
 
-    def DarkOrange(self, *obj, sep=sep_):
+    def DarkOrange(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKORANGE,sep=sep)
 
-    def Orange(self, *obj, sep=sep_):
+    def Orange(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ORANGE,sep=sep)
 
-    def Gold(self, *obj, sep=sep_):
+    def Gold(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GOLD,sep=sep)
 
-    def DarkGoldenRod(self, *obj, sep=sep_):
+    def DarkGoldenRod(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKGOLDENROD,sep=sep)
 
-    def GoldenRod(self, *obj, sep=sep_):
+    def GoldenRod(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GOLDENROD,sep=sep)
 
-    def PaleGoldenRod(self, *obj, sep=sep_):
+    def PaleGoldenRod(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PALEGOLDENROD,sep=sep)
 
-    def DarkKhaki(self, *obj, sep=sep_):
+    def DarkKhaki(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKKHAKI,sep=sep)
 
-    def Khaki(self, *obj, sep=sep_):
+    def Khaki(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.KHAKI,sep=sep)
 
-    def Olive(self, *obj, sep=sep_):
+    def Olive(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.OLIVE,sep=sep)
 
-    def Yellow(self, *obj, sep=sep_):
+    def Yellow(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.YELLOW,sep=sep)
 
-    def YellowGreen(self, *obj, sep=sep_):
+    def YellowGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.YELLOWGREEN,sep=sep)
 
-    def DarkOliveGreen(self, *obj, sep=sep_):
+    def DarkOliveGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKOLIVEGREEN,sep=sep)
 
-    def OliveDrab(self, *obj, sep=sep_):
+    def OliveDrab(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.OLIVEDRAB,sep=sep)
 
-    def LawnGreen(self, *obj, sep=sep_):
+    def LawnGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LAWNGREEN,sep=sep)
 
-    def Chartreuse(self, *obj, sep=sep_):
+    def Chartreuse(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CHARTREUSE,sep=sep)
 
-    def GreenYellow(self, *obj, sep=sep_):
+    def GreenYellow(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GREENYELLOW,sep=sep)
 
-    def DarkGreen(self, *obj, sep=sep_):
+    def DarkGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKGREEN,sep=sep)
 
-    def Green(self, *obj, sep=sep_):
+    def Green(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GREEN,sep=sep)
 
-    def ForestGreen(self, *obj, sep=sep_):
+    def ForestGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.FORESTGREEN,sep=sep)
 
-    def Lime(self, *obj, sep=sep_):
+    def Lime(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIME,sep=sep)
 
-    def LimeGreen(self, *obj, sep=sep_):
+    def LimeGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIMEGREEN,sep=sep)
 
-    def LightGreen(self, *obj, sep=sep_):
+    def LightGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTGREEN,sep=sep)
 
-    def PaleGreen(self, *obj, sep=sep_):
+    def PaleGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PALEGREEN,sep=sep)
 
-    def DarkSeaGreen(self, *obj, sep=sep_):
+    def DarkSeaGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKSEAGREEN,sep=sep)
 
-    def MediumSpringGreen(self, *obj, sep=sep_):
+    def MediumSpringGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMSPRINGGREEN,sep=sep)
 
-    def SpringGreen(self, *obj, sep=sep_):
+    def SpringGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SPRINGGREEN,sep=sep)
 
-    def SeaGreen(self, *obj, sep=sep_):
+    def SeaGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SEAGREEN,sep=sep)
 
-    def MediumAquaMarine(self, *obj, sep=sep_):
+    def MediumAquaMarine(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMAQUAMARINE,sep=sep)
 
-    def MediumSeaGreen(self, *obj, sep=sep_):
+    def MediumSeaGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMSEAGREEN,sep=sep)
 
-    def LightSeaGreen(self, *obj, sep=sep_):
+    def LightSeaGreen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTSEAGREEN,sep=sep)
 
-    def DarkSlateGray(self, *obj, sep=sep_):
+    def DarkSlateGray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKSLATEGRAY,sep=sep)
 
-    def Teal(self, *obj, sep=sep_):
+    def Teal(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.TEAL,sep=sep)
 
-    def DarkCyan(self, *obj, sep=sep_):
+    def DarkCyan(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKCYAN,sep=sep)
 
-    def Aqua(self, *obj, sep=sep_):
+    def Aqua(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.AQUA,sep=sep)
 
-    def Cyan(self, *obj, sep=sep_):
+    def Cyan(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CYAN,sep=sep)
 
-    def LightCyan(self, *obj, sep=sep_):
+    def LightCyan(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTCYAN,sep=sep)
 
-    def DarkTurquoise(self, *obj, sep=sep_):
+    def DarkTurquoise(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKTURQUOISE,sep=sep)
 
-    def Turquoise(self, *obj, sep=sep_):
+    def Turquoise(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.TURQUOISE,sep=sep)
 
-    def MediumTurquoise(self, *obj, sep=sep_):
+    def MediumTurquoise(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMTURQUOISE,sep=sep)
 
-    def PaleTurquoise(self, *obj, sep=sep_):
+    def PaleTurquoise(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PALETURQUOISE,sep=sep)
 
-    def AquaMarine(self, *obj, sep=sep_):
+    def AquaMarine(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.AQUAMARINE,sep=sep)
 
-    def PowderBlue(self, *obj, sep=sep_):
+    def PowderBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.POWDERBLUE,sep=sep)
 
-    def CadetBlue(self, *obj, sep=sep_):
+    def CadetBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CADETBLUE,sep=sep)
 
-    def SteelBlue(self, *obj, sep=sep_):
+    def SteelBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.STEELBLUE,sep=sep)
 
-    def CornFlowerBlue(self, *obj, sep=sep_):
+    def CornFlowerBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CORNFLOWERBLUE,sep=sep)
 
-    def DeepSkyBlue(self, *obj, sep=sep_):
+    def DeepSkyBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DEEPSKYBLUE,sep=sep)
 
-    def DodgerBlue(self, *obj, sep=sep_):
+    def DodgerBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DODGERBLUE,sep=sep)
 
-    def LightBlue(self, *obj, sep=sep_):
+    def LightBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTBLUE,sep=sep)
 
-    def SkyBlue(self, *obj, sep=sep_):
+    def SkyBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SKYBLUE,sep=sep)
 
-    def LightSkyBlue(self, *obj, sep=sep_):
+    def LightSkyBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTSKYBLUE,sep=sep)
 
-    def MidnightBlue(self, *obj, sep=sep_):
+    def MidnightBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MIDNIGHTBLUE,sep=sep)
 
-    def Navy(self, *obj, sep=sep_):
+    def Navy(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.NAVY,sep=sep)
 
-    def DarkBlue(self, *obj, sep=sep_):
+    def DarkBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKBLUE,sep=sep)
 
-    def MediumBlue(self, *obj, sep=sep_):
+    def MediumBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMBLUE,sep=sep)
 
-    def Blue(self, *obj, sep=sep_):
+    def Blue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BLUE,sep=sep)
 
-    def RoyalBlue(self, *obj, sep=sep_):
+    def RoyalBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ROYALBLUE,sep=sep)
 
-    def BlueViolet(self, *obj, sep=sep_):
+    def BlueViolet(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BLUEVIOLET,sep=sep)
 
-    def Indigo(self, *obj, sep=sep_):
+    def Indigo(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.INDIGO,sep=sep)
 
-    def DarkSlateBlue(self, *obj, sep=sep_):
+    def DarkSlateBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKSLATEBLUE,sep=sep)
 
-    def SlateBlue(self, *obj, sep=sep_):
+    def SlateBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SLATEBLUE,sep=sep)
 
-    def MediumSlateBlue(self, *obj, sep=sep_):
+    def MediumSlateBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMSLATEBLUE,sep=sep)
 
-    def MediumPurple(self, *obj, sep=sep_):
+    def MediumPurple(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMPURPLE,sep=sep)
 
-    def DarkMagenta(self, *obj, sep=sep_):
+    def DarkMagenta(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKMAGENTA,sep=sep)
 
-    def DarkViolet(self, *obj, sep=sep_):
+    def DarkViolet(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKVIOLET,sep=sep)
 
-    def DarkOrchid(self, *obj, sep=sep_):
+    def DarkOrchid(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKORCHID,sep=sep)
 
-    def MediumOrchid(self, *obj, sep=sep_):
+    def MediumOrchid(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMORCHID,sep=sep)
 
-    def Purple(self, *obj, sep=sep_):
+    def Purple(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PURPLE,sep=sep)
 
-    def Thistle(self, *obj, sep=sep_):
+    def Thistle(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.THISTLE,sep=sep)
 
-    def Plum(self, *obj, sep=sep_):
+    def Plum(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PLUM,sep=sep)
 
-    def Violet(self, *obj, sep=sep_):
+    def Violet(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.VIOLET,sep=sep)
 
-    def Magenta(self, *obj, sep=sep_):
+    def Magenta(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MAGENTA,sep=sep)
 
-    def Orchid(self, *obj, sep=sep_):
+    def Orchid(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ORCHID,sep=sep)
 
-    def MediumVioletRed(self, *obj, sep=sep_):
+    def MediumVioletRed(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MEDIUMVIOLETRED,sep=sep)
 
-    def PaleVioletRed(self, *obj, sep=sep_):
+    def PaleVioletRed(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PALEVIOLETRED,sep=sep)
 
-    def DeepPink(self, *obj, sep=sep_):
+    def DeepPink(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DEEPPINK,sep=sep)
 
-    def HotPink(self, *obj, sep=sep_):
+    def HotPink(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.HOTPINK,sep=sep)
 
-    def LightPink(self, *obj, sep=sep_):
+    def LightPink(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTPINK,sep=sep)
 
-    def Pink(self, *obj, sep=sep_):
+    def Pink(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PINK,sep=sep)
 
-    def AntiqueWhite(self, *obj, sep=sep_):
+    def AntiqueWhite(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ANTIQUEWHITE,sep=sep)
 
-    def Beige(self, *obj, sep=sep_):
+    def Beige(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BEIGE,sep=sep)
 
-    def Bisque(self, *obj, sep=sep_):
+    def Bisque(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BISQUE,sep=sep)
 
-    def BlanchedAlmond(self, *obj, sep=sep_):
+    def BlanchedAlmond(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BLANCHEDALMOND,sep=sep)
 
-    def Wheat(self, *obj, sep=sep_):
+    def Wheat(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.WHEAT,sep=sep)
 
-    def CornSilk(self, *obj, sep=sep_):
+    def CornSilk(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CORNSILK,sep=sep)
 
-    def LemonChiffon(self, *obj, sep=sep_):
+    def LemonChiffon(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LEMONCHIFFON,sep=sep)
 
-    def LightGoldenRodYellow(self, *obj, sep=sep_):
+    def LightGoldenRodYellow(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTGOLDENRODYELLOW,sep=sep)
 
-    def LightYellow(self, *obj, sep=sep_):
+    def LightYellow(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTYELLOW,sep=sep)
 
-    def SaddleBrown(self, *obj, sep=sep_):
+    def SaddleBrown(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SADDLEBROWN,sep=sep)
 
-    def Sienna(self, *obj, sep=sep_):
+    def Sienna(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SIENNA,sep=sep)
 
-    def Chocolate(self, *obj, sep=sep_):
+    def Chocolate(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.CHOCOLATE,sep=sep)
 
-    def Peru(self, *obj, sep=sep_):
+    def Peru(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PERU,sep=sep)
 
-    def SandyBrown(self, *obj, sep=sep_):
+    def SandyBrown(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SANDYBROWN,sep=sep)
 
-    def BurlyWood(self, *obj, sep=sep_):
+    def BurlyWood(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BURLYWOOD,sep=sep)
 
-    def Tan(self, *obj, sep=sep_):
+    def Tan(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.TAN,sep=sep)
 
-    def RosyBrown(self, *obj, sep=sep_):
+    def RosyBrown(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ROSYBROWN,sep=sep)
 
-    def Moccasin(self, *obj, sep=sep_):
+    def Moccasin(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MOCCASIN,sep=sep)
 
-    def NavajoWhite(self, *obj, sep=sep_):
+    def NavajoWhite(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.NAVAJOWHITE,sep=sep)
 
-    def PeachPuff(self, *obj, sep=sep_):
+    def PeachPuff(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PEACHPUFF,sep=sep)
 
-    def MistyRose(self, *obj, sep=sep_):
+    def MistyRose(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MISTYROSE,sep=sep)
 
-    def LavenderBlush(self, *obj, sep=sep_):
+    def LavenderBlush(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LAVENDERBLUSH,sep=sep)
 
-    def Linen(self, *obj, sep=sep_):
+    def Linen(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LINEN,sep=sep)
 
-    def OldLace(self, *obj, sep=sep_):
+    def OldLace(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.OLDLACE,sep=sep)
 
-    def PapayaWhip(self, *obj, sep=sep_):
+    def PapayaWhip(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.PAPAYAWHIP,sep=sep)
 
-    def WeaShell(self, *obj, sep=sep_):
+    def WeaShell(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.WEASHELL,sep=sep)
 
-    def MintCream(self, *obj, sep=sep_):
+    def MintCream(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.MINTCREAM,sep=sep)
 
-    def SlateGray(self, *obj, sep=sep_):
+    def SlateGray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SLATEGRAY,sep=sep)
 
-    def LightSlateGray(self, *obj, sep=sep_):
+    def LightSlateGray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTSLATEGRAY,sep=sep)
 
-    def LightSteelBlue(self, *obj, sep=sep_):
+    def LightSteelBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTSTEELBLUE,sep=sep)
 
-    def Lavender(self, *obj, sep=sep_):
+    def Lavender(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LAVENDER,sep=sep)
 
-    def FloralWhite(self, *obj, sep=sep_):
+    def FloralWhite(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.FLORALWHITE,sep=sep)
 
-    def AliceBlue(self, *obj, sep=sep_):
+    def AliceBlue(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.ALICEBLUE,sep=sep)
 
-    def GhostWhite(self, *obj, sep=sep_):
+    def GhostWhite(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GHOSTWHITE,sep=sep)
 
-    def Honeydew(self, *obj, sep=sep_):
+    def Honeydew(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.HONEYDEW,sep=sep)
 
-    def Ivory(self, *obj, sep=sep_):
+    def Ivory(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.IVORY,sep=sep)
 
-    def Azure(self, *obj, sep=sep_):
+    def Azure(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.AZURE,sep=sep)
 
-    def Snow(self, *obj, sep=sep_):
+    def Snow(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SNOW,sep=sep)
 
-    def Black(self, *obj, sep=sep_):
+    def Black(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.BLACK,sep=sep)
 
-    def DimGray(self, *obj, sep=sep_):
+    def DimGray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DIMGRAY,sep=sep)
 
-    def Gray(self, *obj, sep=sep_):
+    def Gray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GRAY,sep=sep)
 
-    def DarkGray(self, *obj, sep=sep_):
+    def DarkGray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.DARKGRAY,sep=sep)
 
-    def Silver(self, *obj, sep=sep_):
+    def Silver(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.SILVER,sep=sep)
 
-    def LightGray(self, *obj, sep=sep_):
+    def LightGray(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.LIGHTGRAY,sep=sep)
 
-    def Gainsboro(self, *obj, sep=sep_):
+    def Gainsboro(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.GAINSBORO,sep=sep)
 
-    def WhiteSmoke(self, *obj, sep=sep_):
+    def WhiteSmoke(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.WHITESMOKE,sep=sep)
 
-    def White(self, *obj, sep=sep_):
+    def White(self, *obj:tuple[Any, ...], sep:str=sep_) -> str:
         return self.custom(*obj,color=HtmlColorObjects.WHITE,sep=sep)


### PR DESCRIPTION
every `*obj` gets annotated as `tuple[Any, ...]` which is theoretically correct.
Didn't had much time to look into [PEP 612](https://peps.python.org/pep-0612/) yet which could (eventually) be another option to achieve this. However it first got introduced in Python 3.10 which would break backward compatibility of this library.